### PR TITLE
add libp2p configuration with TCP fallback and connection limits

### DIFF
--- a/crates/production/Cargo.toml
+++ b/crates/production/Cargo.toml
@@ -32,7 +32,7 @@ hyperscale-messages.workspace = true
 rocksdb = "0.24"
 
 # Networking - libp2p with QUIC transport
-libp2p = { version = "0.56.0", features = ["gossipsub", "kad", "request-response", "quic", "tokio", "macros"] }
+libp2p = { version = "0.56.0", features = ["gossipsub", "kad", "request-response", "quic", "tcp", "noise", "yamux", "tokio", "macros"] }
 futures = "0.3"
 async-trait = "0.1"
 


### PR DESCRIPTION
attempting to get node connections working inside docker containers, I added tcp fallback for libp2p which seems to work a bit better than quic/udp