### PR TITLE
State Vote Batching - Experimental - Do not merge

### DIFF
--- a/crates/execution/src/batcher.rs
+++ b/crates/execution/src/batcher.rs
@@ -1,0 +1,469 @@
+//! Vote batching for efficient state vote signatures.
+//!
+//! This module implements Merkle-batched state vote signing, where validators
+//! sign a single Merkle root covering all their votes instead of signing each
+//! vote individually. This reduces BLS signature operations from O(n) to O(1)
+//! per block, providing ~100x speedup for signature generation.
+//!
+//! # Design
+//!
+//! The VoteBatcher collects pending votes and, on flush, builds a Merkle tree
+//! over the sorted vote hashes. The validator signs the Merkle root once, and
+//! each resulting StateVoteBlock carries the shared signature plus its own
+//! Merkle inclusion proof.
+//!
+//! # Usage
+//!
+//! Two batching modes are supported:
+//!
+//! 1. **Block batches**: Single-shard transactions within a block are batched
+//!    together. Flushed when block execution completes.
+//!
+//! 2. **Latent batches**: Cross-shard transactions that complete asynchronously
+//!    are batched on a timer or size threshold.
+
+use hyperscale_types::{
+    batched_vote_message, build_merkle_tree_with_proofs, vote_leaf_hash, Hash, KeyPair,
+    ShardGroupId, StateVoteBlock, ValidatorId,
+};
+use std::time::Duration;
+
+/// Pending vote data before merkle batching.
+#[derive(Debug, Clone)]
+pub struct PendingVote {
+    /// Transaction hash.
+    pub tx_hash: Hash,
+    /// Merkle root of execution outputs.
+    pub state_root: Hash,
+    /// Whether execution succeeded.
+    pub success: bool,
+}
+
+/// Block-level batch of votes (flushed with block).
+#[derive(Debug)]
+struct BlockBatch {
+    /// Block height being executed.
+    block_height: u64,
+    /// Accumulated votes for this block.
+    votes: Vec<PendingVote>,
+}
+
+/// Batches state votes for efficient merkle-based signing.
+///
+/// Instead of signing each vote individually (O(n) BLS signatures per block),
+/// builds a Merkle tree over all votes and signs the root once (O(1)).
+/// Each vote carries a Merkle proof for verification.
+///
+/// This struct is deterministic - timing for latent vote flushing is controlled
+/// by the caller passing the current time to relevant methods.
+pub struct VoteBatcher {
+    /// Block-level batch for single-shard transactions.
+    /// Flushed when block execution completes.
+    block_batch: Option<BlockBatch>,
+
+    /// Pending latent votes (cross-shard, async completion).
+    /// Flushed on timer or size threshold.
+    latent_pending: Vec<PendingVote>,
+
+    /// Time when latent votes were last flushed (deterministic, caller-provided).
+    latent_last_flush: Duration,
+
+    /// Signing key for creating signatures.
+    signing_key: KeyPair,
+
+    /// Local shard group.
+    shard: ShardGroupId,
+
+    /// Validator ID (derived from signing key).
+    validator_id: ValidatorId,
+
+    /// Flush latent votes after this duration.
+    latent_flush_interval: Duration,
+
+    /// Flush latent votes when this many accumulate.
+    latent_flush_threshold: usize,
+}
+
+impl VoteBatcher {
+    /// Create a new vote batcher.
+    pub fn new(signing_key: KeyPair, shard: ShardGroupId, validator_id: ValidatorId) -> Self {
+        Self {
+            block_batch: None,
+            latent_pending: Vec::new(),
+            latent_last_flush: Duration::ZERO,
+            signing_key,
+            shard,
+            validator_id,
+            // Latent votes (cross-shard) flush immediately by default.
+            // This ensures livelock resolution isn't delayed by batching.
+            // Block votes still benefit from batching since they're flushed together.
+            latent_flush_interval: Duration::from_millis(1),
+            latent_flush_threshold: 1,
+        }
+    }
+
+    /// Create a new vote batcher with custom latent flush parameters.
+    pub fn with_latent_config(
+        signing_key: KeyPair,
+        shard: ShardGroupId,
+        validator_id: ValidatorId,
+        latent_flush_interval: Duration,
+        latent_flush_threshold: usize,
+    ) -> Self {
+        Self {
+            block_batch: None,
+            latent_pending: Vec::new(),
+            latent_last_flush: Duration::ZERO,
+            signing_key,
+            shard,
+            validator_id,
+            latent_flush_interval,
+            latent_flush_threshold,
+        }
+    }
+
+    /// Add a single-shard vote to the current block batch.
+    ///
+    /// Call this during block execution for each single-shard transaction.
+    /// The batch is flushed when `flush_block()` is called.
+    pub fn add_block_vote(&mut self, block_height: u64, vote: PendingVote) {
+        let batch = self.block_batch.get_or_insert_with(|| BlockBatch {
+            block_height,
+            votes: Vec::new(),
+        });
+
+        // Sanity check: all votes in a batch should be for the same block
+        debug_assert_eq!(
+            batch.block_height, block_height,
+            "Block height mismatch in vote batch"
+        );
+
+        batch.votes.push(vote);
+    }
+
+    /// Add a cross-shard (latent) vote.
+    ///
+    /// Latent votes are batched separately and flushed on a timer or size threshold.
+    /// The `now` parameter should be the current deterministic time.
+    /// Returns any votes ready to broadcast (if flush threshold reached).
+    pub fn add_latent_vote(&mut self, vote: PendingVote, now: Duration) -> Vec<StateVoteBlock> {
+        self.latent_pending.push(vote);
+
+        // Check if we should flush latent votes
+        if now.saturating_sub(self.latent_last_flush) > self.latent_flush_interval
+            || self.latent_pending.len() >= self.latent_flush_threshold
+        {
+            self.flush_latent(now)
+        } else {
+            vec![]
+        }
+    }
+
+    /// Flush the block batch and return signed StateVoteBlocks.
+    ///
+    /// Call this after block execution completes to get all votes for broadcast.
+    pub fn flush_block(&mut self) -> Vec<StateVoteBlock> {
+        let Some(batch) = self.block_batch.take() else {
+            return vec![];
+        };
+
+        if batch.votes.is_empty() {
+            return vec![];
+        }
+
+        self.create_batched_votes(batch.votes, Some(batch.block_height))
+    }
+
+    /// Flush latent votes and return signed StateVoteBlocks.
+    ///
+    /// The `now` parameter should be the current deterministic time.
+    /// Call this periodically (e.g., on timer tick) to flush pending latent votes.
+    pub fn flush_latent(&mut self, now: Duration) -> Vec<StateVoteBlock> {
+        if self.latent_pending.is_empty() {
+            return vec![];
+        }
+
+        let votes = std::mem::take(&mut self.latent_pending);
+        self.latent_last_flush = now;
+
+        // Latent votes use None for block height (encoded as 0 in signing message)
+        self.create_batched_votes(votes, None)
+    }
+
+    /// Check if there are pending latent votes that should be flushed.
+    ///
+    /// The `now` parameter should be the current deterministic time.
+    pub fn should_flush_latent(&self, now: Duration) -> bool {
+        !self.latent_pending.is_empty()
+            && (now.saturating_sub(self.latent_last_flush) > self.latent_flush_interval
+                || self.latent_pending.len() >= self.latent_flush_threshold)
+    }
+
+    /// Get the number of pending block votes.
+    pub fn pending_block_votes(&self) -> usize {
+        self.block_batch.as_ref().map_or(0, |b| b.votes.len())
+    }
+
+    /// Get the number of pending latent votes.
+    pub fn pending_latent_votes(&self) -> usize {
+        self.latent_pending.len()
+    }
+
+    /// Common path: build merkle tree, sign once, create vote blocks.
+    fn create_batched_votes(
+        &self,
+        mut votes: Vec<PendingVote>,
+        block_height: Option<u64>,
+    ) -> Vec<StateVoteBlock> {
+        if votes.is_empty() {
+            return vec![];
+        }
+
+        // 1. Sort votes deterministically by tx_hash
+        votes.sort_by(|a, b| a.tx_hash.cmp(&b.tx_hash));
+
+        // 2. Compute leaf hashes for merkle tree
+        let leaf_hashes: Vec<Hash> = votes
+            .iter()
+            .map(|v| vote_leaf_hash(&v.tx_hash, &v.state_root, self.shard.0, v.success))
+            .collect();
+
+        // 3. Build merkle tree and get proofs
+        let (merkle_root, proofs) = build_merkle_tree_with_proofs(&leaf_hashes);
+
+        // 4. Sign merkle root ONCE
+        let message = batched_vote_message(self.shard, block_height, &merkle_root);
+        let signature = self.signing_key.sign(&message);
+
+        // 5. Create vote blocks with proofs
+        votes
+            .into_iter()
+            .zip(proofs)
+            .map(|(vote, proof)| StateVoteBlock {
+                transaction_hash: vote.tx_hash,
+                shard_group_id: self.shard,
+                state_root: vote.state_root,
+                success: vote.success,
+                validator: self.validator_id,
+                signature: signature.clone(),
+                vote_merkle_root: merkle_root,
+                vote_merkle_proof: proof,
+                batch_block_height: block_height,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_keypair() -> KeyPair {
+        KeyPair::generate_bls()
+    }
+
+    #[test]
+    fn test_empty_flush() {
+        let keypair = test_keypair();
+        let mut batcher = VoteBatcher::new(keypair, ShardGroupId(0), ValidatorId(0));
+
+        // Empty flushes should return empty vecs
+        assert!(batcher.flush_block().is_empty());
+        assert!(batcher.flush_latent(Duration::ZERO).is_empty());
+    }
+
+    #[test]
+    fn test_single_block_vote() {
+        let keypair = test_keypair();
+        let mut batcher = VoteBatcher::new(keypair, ShardGroupId(0), ValidatorId(0));
+
+        let vote = PendingVote {
+            tx_hash: Hash::from_bytes(b"tx1"),
+            state_root: Hash::from_bytes(b"root1"),
+            success: true,
+        };
+
+        batcher.add_block_vote(100, vote);
+        let votes = batcher.flush_block();
+
+        assert_eq!(votes.len(), 1);
+        assert!(votes[0].verify_merkle_proof());
+        assert_eq!(votes[0].batch_block_height, Some(100));
+    }
+
+    #[test]
+    fn test_multiple_block_votes() {
+        let keypair = test_keypair();
+        let mut batcher = VoteBatcher::new(keypair, ShardGroupId(0), ValidatorId(0));
+
+        // Add 10 votes
+        for i in 0..10 {
+            let vote = PendingVote {
+                tx_hash: Hash::from_bytes(&[i; 32]),
+                state_root: Hash::from_bytes(&[i + 100; 32]),
+                success: i % 2 == 0,
+            };
+            batcher.add_block_vote(200, vote);
+        }
+
+        let votes = batcher.flush_block();
+
+        assert_eq!(votes.len(), 10);
+
+        // All votes should share the same merkle root and signature
+        let first_root = &votes[0].vote_merkle_root;
+        let first_sig = &votes[0].signature;
+
+        for vote in &votes {
+            assert!(vote.verify_merkle_proof());
+            assert_eq!(&vote.vote_merkle_root, first_root);
+            assert_eq!(&vote.signature, first_sig);
+            assert_eq!(vote.batch_block_height, Some(200));
+        }
+    }
+
+    #[test]
+    fn test_latent_votes() {
+        let keypair = test_keypair();
+        // Use custom config with higher threshold to test batching behavior
+        let mut batcher = VoteBatcher::with_latent_config(
+            keypair,
+            ShardGroupId(1),
+            ValidatorId(1),
+            Duration::from_millis(50),
+            50, // threshold
+        );
+
+        // Start at time=0, add votes within the flush interval (50ms)
+        // Each vote is added at the same time, so no time-based flush occurs
+        let start_time = Duration::ZERO;
+
+        // Add votes below threshold (threshold is 50, we add 10)
+        for i in 0..10 {
+            let vote = PendingVote {
+                tx_hash: Hash::from_bytes(&[i; 32]),
+                state_root: Hash::from_bytes(&[i + 50; 32]),
+                success: true,
+            };
+            // All votes added at same time, within flush interval
+            let result = batcher.add_latent_vote(vote, start_time);
+            // Should not flush yet (threshold is 50 and time hasn't elapsed)
+            assert!(result.is_empty(), "Vote {} unexpectedly triggered flush", i);
+        }
+
+        assert_eq!(batcher.pending_latent_votes(), 10);
+
+        // Manual flush at a later time
+        let flush_time = Duration::from_millis(100); // After flush interval
+        let votes = batcher.flush_latent(flush_time);
+        assert_eq!(votes.len(), 10);
+
+        for vote in &votes {
+            assert!(vote.verify_merkle_proof());
+            // Latent votes have no block height
+            assert_eq!(vote.batch_block_height, None);
+        }
+
+        assert_eq!(batcher.pending_latent_votes(), 0);
+    }
+
+    #[test]
+    fn test_latent_votes_immediate_flush() {
+        let keypair = test_keypair();
+        // Default config flushes immediately (threshold=1)
+        let mut batcher = VoteBatcher::new(keypair, ShardGroupId(1), ValidatorId(1));
+
+        let vote = PendingVote {
+            tx_hash: Hash::from_bytes(&[1; 32]),
+            state_root: Hash::from_bytes(&[2; 32]),
+            success: true,
+        };
+
+        // With default config, first vote triggers immediate flush
+        let result = batcher.add_latent_vote(vote, Duration::from_millis(10));
+        assert_eq!(result.len(), 1);
+        assert!(result[0].verify_merkle_proof());
+        assert_eq!(result[0].batch_block_height, None);
+    }
+
+    #[test]
+    fn test_votes_sorted_deterministically() {
+        let keypair = test_keypair();
+        let mut batcher = VoteBatcher::new(keypair, ShardGroupId(0), ValidatorId(0));
+
+        // Add votes in reverse order
+        for i in (0..5).rev() {
+            let vote = PendingVote {
+                tx_hash: Hash::from_bytes(&[i; 32]),
+                state_root: Hash::from_bytes(&[i; 32]),
+                success: true,
+            };
+            batcher.add_block_vote(1, vote);
+        }
+
+        let votes = batcher.flush_block();
+
+        // Votes should be sorted by tx_hash
+        for i in 0..votes.len() - 1 {
+            assert!(votes[i].transaction_hash < votes[i + 1].transaction_hash);
+        }
+    }
+
+    #[test]
+    fn test_separate_block_batches() {
+        let keypair = test_keypair();
+        let mut batcher = VoteBatcher::new(keypair, ShardGroupId(0), ValidatorId(0));
+
+        // First block
+        batcher.add_block_vote(
+            100,
+            PendingVote {
+                tx_hash: Hash::from_bytes(b"tx1"),
+                state_root: Hash::from_bytes(b"root1"),
+                success: true,
+            },
+        );
+        let votes1 = batcher.flush_block();
+
+        // Second block
+        batcher.add_block_vote(
+            101,
+            PendingVote {
+                tx_hash: Hash::from_bytes(b"tx2"),
+                state_root: Hash::from_bytes(b"root2"),
+                success: true,
+            },
+        );
+        let votes2 = batcher.flush_block();
+
+        // Different blocks should have different merkle roots
+        assert_ne!(votes1[0].vote_merkle_root, votes2[0].vote_merkle_root);
+
+        // Different block heights
+        assert_eq!(votes1[0].batch_block_height, Some(100));
+        assert_eq!(votes2[0].batch_block_height, Some(101));
+    }
+
+    #[test]
+    fn test_signature_verification() {
+        let keypair = test_keypair();
+        let public_key = keypair.public_key();
+        let mut batcher = VoteBatcher::new(keypair, ShardGroupId(0), ValidatorId(0));
+
+        batcher.add_block_vote(
+            50,
+            PendingVote {
+                tx_hash: Hash::from_bytes(b"tx"),
+                state_root: Hash::from_bytes(b"state"),
+                success: true,
+            },
+        );
+
+        let votes = batcher.flush_block();
+        let vote = &votes[0];
+
+        // Verify the signature using the signing message
+        let message = vote.signing_message();
+        assert!(public_key.verify(&message, &vote.signature));
+    }
+}

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -8,8 +8,10 @@
 //! - State provisioning
 //! - Vote aggregation and certificate formation
 
+mod batcher;
 mod pending;
 mod state;
 pub mod trackers;
 
+pub use batcher::{PendingVote, VoteBatcher};
 pub use state::{ExecutionState, DEFAULT_SPECULATIVE_MAX_TXS, DEFAULT_VIEW_CHANGE_COOLDOWN_ROUNDS};

--- a/crates/execution/src/trackers/certificate.rs
+++ b/crates/execution/src/trackers/certificate.rs
@@ -164,19 +164,30 @@ impl CertificateTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use hyperscale_types::{Signature, SignerBitfield};
+    use hyperscale_types::{
+        build_merkle_tree_with_proofs, vote_leaf_hash, Signature, SignerBitfield,
+    };
 
     fn make_certificate(tx_hash: Hash, shard: ShardGroupId, merkle_root: Hash) -> StateCertificate {
+        let success = true;
+
+        // Build merkle tree with single leaf
+        let leaf_hash = vote_leaf_hash(&tx_hash, &merkle_root, shard.0, success);
+        let (vote_merkle_root, proofs) = build_merkle_tree_with_proofs(&[leaf_hash]);
+
         StateCertificate {
             transaction_hash: tx_hash,
             shard_group_id: shard,
             read_nodes: vec![],
             state_writes: vec![],
             outputs_merkle_root: merkle_root,
-            success: true,
+            success,
             aggregated_signature: Signature::zero(),
             signers: SignerBitfield::new(4),
             voting_power: 3,
+            vote_merkle_root,
+            vote_merkle_proof: proofs.into_iter().next().unwrap(),
+            batch_block_height: None,
         }
     }
 

--- a/crates/production/src/storage.rs
+++ b/crates/production/src/storage.rs
@@ -1052,8 +1052,9 @@ mod tests {
     #[test]
     fn test_atomic_certificate_persistence() {
         use hyperscale_types::{
-            NodeId, PartitionNumber, ShardExecutionProof, ShardGroupId, Signature,
-            StateCertificate, SubstateWrite, TransactionCertificate, TransactionDecision,
+            build_merkle_tree_with_proofs, vote_leaf_hash, NodeId, PartitionNumber,
+            ShardExecutionProof, ShardGroupId, Signature, StateCertificate, SubstateWrite,
+            TransactionCertificate, TransactionDecision,
         };
         use std::collections::BTreeMap;
 
@@ -1070,16 +1071,26 @@ mod tests {
             value: vec![99, 88, 77],
         }];
 
+        let outputs_merkle_root = Hash::from_bytes(&[0; 32]);
+        let success = true;
+
+        // Build merkle tree with single leaf
+        let leaf_hash = vote_leaf_hash(&tx_hash, &outputs_merkle_root, shard_group.0, success);
+        let (vote_merkle_root, proofs) = build_merkle_tree_with_proofs(&[leaf_hash]);
+
         let state_cert = StateCertificate {
             transaction_hash: tx_hash,
             shard_group_id: shard_group,
             read_nodes: vec![],
             state_writes: writes.clone(),
-            outputs_merkle_root: Hash::from_bytes(&[0; 32]),
-            success: true,
+            outputs_merkle_root,
+            success,
             aggregated_signature: Signature::zero(),
             signers: hyperscale_types::SignerBitfield::new(4),
             voting_power: 0,
+            vote_merkle_root,
+            vote_merkle_proof: proofs.into_iter().next().unwrap(),
+            batch_block_height: None,
         };
 
         let shard_proof = ShardExecutionProof {
@@ -1273,8 +1284,9 @@ mod tests {
     #[test]
     fn test_certificate_idempotency() {
         use hyperscale_types::{
-            NodeId, PartitionNumber, ShardExecutionProof, ShardGroupId, Signature,
-            StateCertificate, SubstateWrite, TransactionCertificate, TransactionDecision,
+            build_merkle_tree_with_proofs, vote_leaf_hash, NodeId, PartitionNumber,
+            ShardExecutionProof, ShardGroupId, Signature, StateCertificate, SubstateWrite,
+            TransactionCertificate, TransactionDecision,
         };
         use std::collections::BTreeMap;
 
@@ -1290,16 +1302,26 @@ mod tests {
             value: vec![99, 88, 77],
         }];
 
+        let outputs_merkle_root = Hash::from_bytes(&[0; 32]);
+        let success = true;
+
+        // Build merkle tree with single leaf
+        let leaf_hash = vote_leaf_hash(&tx_hash, &outputs_merkle_root, shard_group.0, success);
+        let (vote_merkle_root, proofs) = build_merkle_tree_with_proofs(&[leaf_hash]);
+
         let state_cert = StateCertificate {
             transaction_hash: tx_hash,
             shard_group_id: shard_group,
             read_nodes: vec![],
             state_writes: writes.clone(),
-            outputs_merkle_root: Hash::from_bytes(&[0; 32]),
-            success: true,
+            outputs_merkle_root,
+            success,
             aggregated_signature: Signature::zero(),
             signers: hyperscale_types::SignerBitfield::new(4),
             voting_power: 0,
+            vote_merkle_root,
+            vote_merkle_proof: proofs.into_iter().next().unwrap(),
+            batch_block_height: None,
         };
 
         let shard_proof = ShardExecutionProof {

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -16,6 +16,7 @@
 mod crypto;
 mod hash;
 mod identifiers;
+mod merkle;
 mod network;
 mod signing;
 
@@ -36,10 +37,11 @@ pub use epoch::{
 };
 pub use hash::{Hash, HexError};
 pub use identifiers::{BlockHeight, NodeId, PartitionNumber, ShardGroupId, ValidatorId, VotePower};
+pub use merkle::{build_merkle_tree_with_proofs, vote_leaf_hash, MerkleProof};
 pub use network::{GlobalMessage, NetworkMessage, Request, ShardMessage};
 pub use signing::{
-    block_vote_message, exec_vote_message, state_provision_message, DOMAIN_BLOCK_VOTE,
-    DOMAIN_EXEC_VOTE, DOMAIN_STATE_PROVISION,
+    batched_vote_message, block_vote_message, state_provision_message, DOMAIN_BATCH_STATE_VOTE,
+    DOMAIN_BLOCK_VOTE, DOMAIN_STATE_PROVISION,
 };
 
 pub use block::{Block, BlockHeader};

--- a/crates/types/src/merkle.rs
+++ b/crates/types/src/merkle.rs
@@ -1,0 +1,318 @@
+//! Merkle tree utilities for batched vote signatures.
+//!
+//! This module provides a simple binary Merkle tree implementation optimized
+//! for batching state vote signatures. Each validator signs the Merkle root
+//! of all their votes, and individual votes carry inclusion proofs.
+//!
+//! # Performance
+//!
+//! - Tree construction: O(n) hashes for n leaves
+//! - Proof generation: O(log n) per proof, O(n log n) total
+//! - Proof verification: O(log n) hashes
+//!
+//! For 1000 votes, this is ~10,000 hash operations vs 1000 BLS signatures,
+//! providing ~100x speedup since hashing is ~1000x faster than BLS signing.
+
+use crate::Hash;
+use sbor::prelude::*;
+
+/// Merkle inclusion proof for a leaf in a binary Merkle tree.
+///
+/// The proof consists of sibling hashes from the leaf to the root.
+/// Verification recomputes the path and checks against the expected root.
+#[derive(Clone, Debug, PartialEq, Eq, BasicSbor)]
+pub struct MerkleProof {
+    /// Index of the leaf in the tree (0-based).
+    pub leaf_index: u32,
+
+    /// Sibling hashes from leaf to root.
+    ///
+    /// For a tree of depth d, this contains d-1 hashes.
+    /// siblings[0] is the immediate sibling, siblings[d-2] is near the root.
+    pub siblings: Vec<Hash>,
+}
+
+impl MerkleProof {
+    /// Verify that `leaf_hash` is included in `root` at `leaf_index`.
+    ///
+    /// Returns true if the proof is valid.
+    pub fn verify(&self, leaf_hash: &Hash, root: &Hash) -> bool {
+        let mut current = *leaf_hash;
+        let mut index = self.leaf_index;
+
+        for sibling in &self.siblings {
+            current = if index.is_multiple_of(2) {
+                // Current is left child, sibling is right
+                hash_pair(&current, sibling)
+            } else {
+                // Current is right child, sibling is left
+                hash_pair(sibling, &current)
+            };
+            index /= 2;
+        }
+
+        current == *root
+    }
+
+    /// Get the depth of the tree this proof is for.
+    pub fn depth(&self) -> usize {
+        self.siblings.len()
+    }
+}
+
+/// Hash two child nodes to produce parent hash.
+///
+/// Uses Blake3 with concatenated inputs for efficiency.
+#[inline]
+fn hash_pair(left: &Hash, right: &Hash) -> Hash {
+    let mut data = [0u8; 64];
+    data[..32].copy_from_slice(left.as_bytes());
+    data[32..].copy_from_slice(right.as_bytes());
+    Hash::from_bytes(&data)
+}
+
+/// Build a Merkle tree from leaf hashes and generate proofs for all leaves.
+///
+/// Returns the Merkle root and a proof for each leaf (in the same order as input).
+///
+/// # Algorithm
+///
+/// 1. Pad leaves to next power of 2 with zero hashes
+/// 2. Build tree bottom-up, storing all intermediate nodes
+/// 3. Extract sibling path for each original leaf
+///
+/// # Panics
+///
+/// Panics if `leaves` is empty.
+pub fn build_merkle_tree_with_proofs(leaves: &[Hash]) -> (Hash, Vec<MerkleProof>) {
+    assert!(
+        !leaves.is_empty(),
+        "Cannot build Merkle tree with no leaves"
+    );
+
+    // Handle single leaf case
+    if leaves.len() == 1 {
+        return (
+            leaves[0],
+            vec![MerkleProof {
+                leaf_index: 0,
+                siblings: vec![],
+            }],
+        );
+    }
+
+    // Pad to next power of 2
+    let n = leaves.len().next_power_of_two();
+    let depth = n.trailing_zeros() as usize;
+
+    // Allocate tree storage: 2n - 1 nodes for n leaves
+    // Layout: [leaves (n), level 1 (n/2), level 2 (n/4), ..., root (1)]
+    let mut tree = vec![Hash::ZERO; 2 * n - 1];
+
+    // Copy leaves to start of tree
+    tree[..leaves.len()].copy_from_slice(leaves);
+    // Remaining leaf slots already zeroed (padding)
+
+    // Build tree bottom-up
+    let mut level_start = 0;
+    let mut level_size = n;
+
+    for _ in 0..depth {
+        let next_level_start = level_start + level_size;
+        let next_level_size = level_size / 2;
+
+        for i in 0..next_level_size {
+            let left = &tree[level_start + 2 * i];
+            let right = &tree[level_start + 2 * i + 1];
+            tree[next_level_start + i] = hash_pair(left, right);
+        }
+
+        level_start = next_level_start;
+        level_size = next_level_size;
+    }
+
+    // Root is the last element
+    let root = tree[tree.len() - 1];
+
+    // Generate proofs for original leaves only
+    let proofs: Vec<MerkleProof> = (0..leaves.len())
+        .map(|leaf_idx| {
+            let mut siblings = Vec::with_capacity(depth);
+            let mut level_start = 0;
+            let mut level_size = n;
+            let mut idx = leaf_idx;
+
+            for _ in 0..depth {
+                // Sibling index at this level
+                let sibling_idx = if idx % 2 == 0 { idx + 1 } else { idx - 1 };
+                siblings.push(tree[level_start + sibling_idx]);
+
+                // Move to parent level
+                level_start += level_size;
+                level_size /= 2;
+                idx /= 2;
+            }
+
+            MerkleProof {
+                leaf_index: leaf_idx as u32,
+                siblings,
+            }
+        })
+        .collect();
+
+    (root, proofs)
+}
+
+/// Compute the leaf hash for a state vote.
+///
+/// This produces a deterministic hash of the vote contents for Merkle tree inclusion.
+/// The format matches what validators sign, ensuring the proof covers the actual vote data.
+pub fn vote_leaf_hash(
+    tx_hash: &Hash,
+    state_root: &Hash,
+    shard_group_id: u64,
+    success: bool,
+) -> Hash {
+    // Pre-allocate exact size: 32 + 32 + 8 + 1 = 73 bytes
+    let mut data = Vec::with_capacity(73);
+    data.extend_from_slice(tx_hash.as_bytes());
+    data.extend_from_slice(state_root.as_bytes());
+    data.extend_from_slice(&shard_group_id.to_le_bytes());
+    data.push(if success { 1 } else { 0 });
+    Hash::from_bytes(&data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_leaf() {
+        let leaf = Hash::from_bytes(b"single leaf");
+        let (root, proofs) = build_merkle_tree_with_proofs(&[leaf]);
+
+        assert_eq!(root, leaf);
+        assert_eq!(proofs.len(), 1);
+        assert!(proofs[0].verify(&leaf, &root));
+    }
+
+    #[test]
+    fn test_two_leaves() {
+        let leaf0 = Hash::from_bytes(b"leaf 0");
+        let leaf1 = Hash::from_bytes(b"leaf 1");
+        let (root, proofs) = build_merkle_tree_with_proofs(&[leaf0, leaf1]);
+
+        // Root should be hash of the two leaves
+        let expected_root = hash_pair(&leaf0, &leaf1);
+        assert_eq!(root, expected_root);
+
+        // Both proofs should verify
+        assert_eq!(proofs.len(), 2);
+        assert!(proofs[0].verify(&leaf0, &root));
+        assert!(proofs[1].verify(&leaf1, &root));
+
+        // Proofs should have depth 1
+        assert_eq!(proofs[0].depth(), 1);
+        assert_eq!(proofs[1].depth(), 1);
+    }
+
+    #[test]
+    fn test_four_leaves() {
+        let leaves: Vec<Hash> = (0..4).map(|i| Hash::from_bytes(&[i])).collect();
+        let (root, proofs) = build_merkle_tree_with_proofs(&leaves);
+
+        // All proofs should verify
+        for (i, (proof, leaf)) in proofs.iter().zip(leaves.iter()).enumerate() {
+            assert!(proof.verify(leaf, &root), "Proof {} failed to verify", i);
+            assert_eq!(proof.leaf_index, i as u32);
+            assert_eq!(proof.depth(), 2); // log2(4) = 2
+        }
+    }
+
+    #[test]
+    fn test_non_power_of_two_leaves() {
+        // 5 leaves -> padded to 8
+        let leaves: Vec<Hash> = (0..5).map(|i| Hash::from_bytes(&[i])).collect();
+        let (root, proofs) = build_merkle_tree_with_proofs(&leaves);
+
+        // All 5 proofs should verify
+        assert_eq!(proofs.len(), 5);
+        for (i, (proof, leaf)) in proofs.iter().zip(leaves.iter()).enumerate() {
+            assert!(proof.verify(leaf, &root), "Proof {} failed to verify", i);
+            assert_eq!(proof.depth(), 3); // ceil(log2(5)) = 3
+        }
+    }
+
+    #[test]
+    fn test_large_tree() {
+        // 1000 leaves (realistic batch size)
+        let leaves: Vec<Hash> = (0u32..1000)
+            .map(|i| Hash::from_bytes(&i.to_le_bytes()))
+            .collect();
+        let (root, proofs) = build_merkle_tree_with_proofs(&leaves);
+
+        // All proofs should verify
+        assert_eq!(proofs.len(), 1000);
+        for (i, (proof, leaf)) in proofs.iter().zip(leaves.iter()).enumerate() {
+            assert!(proof.verify(leaf, &root), "Proof {} failed to verify", i);
+            assert_eq!(proof.depth(), 10); // ceil(log2(1000)) = 10
+        }
+    }
+
+    #[test]
+    fn test_proof_rejects_wrong_leaf() {
+        let leaves: Vec<Hash> = (0..4).map(|i| Hash::from_bytes(&[i])).collect();
+        let (root, proofs) = build_merkle_tree_with_proofs(&leaves);
+
+        // Proof for leaf 0 should not verify with leaf 1's hash
+        assert!(!proofs[0].verify(&leaves[1], &root));
+    }
+
+    #[test]
+    fn test_proof_rejects_wrong_root() {
+        let leaves: Vec<Hash> = (0..4).map(|i| Hash::from_bytes(&[i])).collect();
+        let (root, proofs) = build_merkle_tree_with_proofs(&leaves);
+
+        let wrong_root = Hash::from_bytes(b"wrong root");
+        assert!(!proofs[0].verify(&leaves[0], &wrong_root));
+        assert_eq!(root, root); // Suppress unused warning
+    }
+
+    #[test]
+    fn test_vote_leaf_hash_deterministic() {
+        let tx_hash = Hash::from_bytes(b"tx");
+        let state_root = Hash::from_bytes(b"state");
+
+        let hash1 = vote_leaf_hash(&tx_hash, &state_root, 1, true);
+        let hash2 = vote_leaf_hash(&tx_hash, &state_root, 1, true);
+
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_vote_leaf_hash_differs_on_fields() {
+        let tx_hash = Hash::from_bytes(b"tx");
+        let state_root = Hash::from_bytes(b"state");
+
+        let base = vote_leaf_hash(&tx_hash, &state_root, 1, true);
+
+        // Different shard
+        let diff_shard = vote_leaf_hash(&tx_hash, &state_root, 2, true);
+        assert_ne!(base, diff_shard);
+
+        // Different success
+        let diff_success = vote_leaf_hash(&tx_hash, &state_root, 1, false);
+        assert_ne!(base, diff_success);
+
+        // Different tx_hash
+        let other_tx = Hash::from_bytes(b"other");
+        let diff_tx = vote_leaf_hash(&other_tx, &state_root, 1, true);
+        assert_ne!(base, diff_tx);
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot build Merkle tree with no leaves")]
+    fn test_empty_leaves_panics() {
+        build_merkle_tree_with_proofs(&[]);
+    }
+}


### PR DESCRIPTION
This PR covers an implementation of state vote batching similar to how the Java reference does it.

It requires further testing in order to judge whether it's practically useful under realistic workloads

Pros:
- only one merkle root to verify for a whole batch of transactions (less pressure on crypto cores)

Cons:
- requires artificially holding back the entire txn set to prepare batch - even if votes are ready _now_ and could go onto form state certificates, transaction certificates - creating lower latencies and unlocking state quicker (more overall TPS)
- causes uneven pressure/burstiness in different parts of the pipeline, network, etc. by artificially consolidating txn batches into discrete lumps

Seeing minor performance regressions testing this on LAN.

But leaving the PR open as a reminder to bench this on a proper WAN deployment