### PR TITLE
Fix DNS resolving issue of host.docker.internal in linux environment

### DIFF
--- a/scripts/monitoring/docker-compose.yml
+++ b/scripts/monitoring/docker-compose.yml
@@ -22,7 +22,8 @@ services:
       - '--storage.tsdb.path=/prometheus'
       - '--storage.tsdb.retention.time=7d'
       - '--web.enable-lifecycle'
-
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     restart: unless-stopped
 
   grafana:


### PR DESCRIPTION
host.docker.internal is not available on Linux by default.

The special DNS name host.docker.internal is automatically available in Docker Desktop for Windows and macOS but is not guaranteed in all Linux environments. 

Specifying extra_hosts mapping to gateway solve the issue