### PR TITLE
Add age-based cleanup for early wave attestations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# hyperscale-rs — BFT Consensus Protocol
+
+## What This Is
+Rust implementation of the Hyperscale consensus protocol for Radix. Sharded BFT based on HotStuff-2 with deterministic simulation testing. Community project — "try to break it."
+
+## Repo
+- Upstream: https://github.com/hyperscalers/hyperscale-rs
+- Fork: https://github.com/bigdevxrd/hyperscale-rs
+
+## Stack
+- Rust workspace monorepo
+- 20+ crates in crates/
+- Key crates: bft, core, execution, engine, simulation, node, production
+- libp2p for networking, RocksDB for storage
+
+## Key Architecture
+- Two-chain commit (HotStuff-2 based)
+- Optimistic pipelining — propose immediately after QC formation
+- Cross-shard 2PC for multi-shard transactions
+- Deterministic simulation as first-class testing
+- Radix Engine integration for smart contract execution
+
+## Contributing Focus
+- Issue #22: Unbounded in-memory data structures (DoS vector) — HIGH PRIORITY
+- Issue #18: Transaction/substate test suite (test gap)
+- Issue #17: Fee model in sharded RE (design hole)
+- See openclaw-bert/workspace/PROJECT-HYPERSCALERS.md for Bert's full analysis
+
+## Build
+```bash
+cargo check  # verify compiles
+cargo test   # run test suite
+```

--- a/CONTRIBUTION-PLAN.md
+++ b/CONTRIBUTION-PLAN.md
@@ -1,0 +1,200 @@
+# Hyperscale-RS — Contribution Plan
+> bigdev (@bigdevxrd) | Updated: 2026-04-09
+
+## The Opportunity
+
+Hyperscale-rs is a 55,812-line Rust BFT consensus protocol with Radix Engine integration. 28 crates, 738 tests, active development (10 commits Apr 8, 5 PRs merged in 2 weeks). The maintainer tagged 21 open issues and explicitly asked for contributions ("try to break it").
+
+We posted a detailed security audit on #22 (unbounded data structures) — first external contribution. No response yet but the team is clearly active. Hashlock (security firm) is also watching the repo.
+
+## Codebase Profile
+
+| Metric | Value |
+|--------|-------|
+| Total Rust LOC | 55,812 |
+| Crates | 28 |
+| Tests | 738 |
+| Open Issues | 21 |
+| Recent PRs | 5 merged in 2 weeks |
+| CI | GitHub Actions (check, test, clippy, Docker, release) |
+| Key Dependency | Radix Engine (forked radixdlt-scrypto) |
+
+### Crate Complexity (where to focus)
+
+| Crate | LOC | Risk | Our Skill Fit |
+|-------|-----|------|---------------|
+| **bft** | 11,925 | Highest — core consensus | Strong (Rust + protocol knowledge) |
+| **types** | 7,157 | Foundation — changes ripple everywhere | Medium (careful, low risk) |
+| **execution** | 2,776 | Cross-shard 2PC | Strong (we understand Radix execution) |
+| **mempool** | 2,151 | Our audit target | Strong (we identified the bugs) |
+| **engine** | 2,083 | Radix Engine integration | Very strong (Scrypto expertise) |
+| **livelock** | 1,524 | Deadlock detection | Medium |
+| **node** | 1,840 | I/O loop composition | Medium |
+
+## Contribution Path (Ordered by Impact × Feasibility)
+
+### Phase 1: Establish Credibility (Weeks 1-2)
+
+#### PR #1: Bounded Mempool Pool (Issue #22)
+**Target:** `crates/mempool/src/state.rs`
+**Problem:** `pool: BTreeMap<Hash, PoolEntry>` has no size limit. `DEFAULT_IN_FLIGHT_LIMIT` (12,288) only throttles proposals, doesn't evict.
+**Fix:**
+1. Add `max_pool_size: usize` to `MempoolConfig` (default: 50,000)
+2. Add `fn maybe_evict(&mut self)` called after every `pool.insert()`
+3. Eviction strategy: FIFO by `PoolEntry.created_at` (simplest, least controversial)
+4. Add metric: `mempool_pool_size` gauge
+5. Add test: pool grows to limit, then evicts oldest on next insert
+
+**What to read first:**
+- `crates/mempool/src/state.rs` lines 1-50 (struct + config)
+- `crates/mempool/src/state.rs` search for `.insert(` (insertion points)
+- `crates/core/src/lib.rs` for `Action` enum (if we need new actions)
+
+**Estimated effort:** 4-6 hours
+**Risk:** Low — mempool is self-contained, doesn't affect consensus
+**Why first:** Directly addresses our audit finding. Clean, testable, non-controversial.
+
+#### PR #2: Livelock Tombstone Cleanup (Issue #22)
+**Target:** `crates/livelock/src/state.rs`
+**Problem:** `tombstones: HashMap<Hash, Duration>` has no cleanup loop despite `tombstone_ttl` config.
+**Fix:**
+1. Add `fn cleanup_tombstones(&mut self, committed_height: u64)` matching the pattern in `mempool::cleanup_old_tombstones()`
+2. Call from node's commit path (in `crates/node/src/state.rs`)
+3. Add metric: `livelock_tombstone_count` gauge
+4. Add test: tombstones are cleaned after retention period
+
+**Estimated effort:** 2-3 hours
+**Risk:** Low — cleanup is additive, doesn't change livelock logic
+**Why second:** Small, clean, directly from our audit. Builds trust.
+
+### Phase 2: Deeper Contributions (Weeks 3-4)
+
+#### PR #3: Execution Early State Cleanup (Issue #22)
+**Target:** `crates/execution/src/state.rs`
+**Problem:** `early_provisioning_complete`, `early_certificates`, `early_votes` leak entries when blocks are orphaned.
+**Fix:**
+1. In `prune_execution_state()`, add age-based cleanup for all `early_*` maps
+2. Remove entries where block height < `committed_height - 100`
+3. Add bounded capacity to inner `Vec` (cap at 1000 entries per key)
+4. Add tests for orphaned block cleanup
+
+**Estimated effort:** 4-6 hours
+**Risk:** Medium — execution state is more delicate, needs careful testing
+**Why third:** Completes the #22 audit triage. Three PRs = comprehensive fix.
+
+#### PR #4: Benchmarks (Issue #15)
+**Target:** New `benches/` directories in key crates
+**Problem:** No benchmarks exist. Can't measure impact of changes.
+**Fix:**
+1. `crates/bft/benches/` — vote aggregation, QC formation (hot path)
+2. `crates/mempool/benches/` — insert/evict/propose (with our bounded fix)
+3. `crates/execution/benches/` — vote tracking, certificate formation
+4. Use `criterion` crate for statistical benchmarks
+5. Add to CI as optional step
+
+**Estimated effort:** 6-8 hours
+**Risk:** Low — additive, no logic changes
+**Why fourth:** Demonstrates engineering maturity. Every future PR can show perf impact.
+
+### Phase 3: Protocol-Level Contributions (Months 2-3)
+
+#### PR #5: Transaction/Substate Test Suite (Issue #18)
+**Target:** `crates/simulation/tests/`
+**Problem:** No dedicated test suite for transaction lifecycle through the full stack.
+**Fix:**
+1. Single-shard transaction: submit → propose → execute → commit
+2. Cross-shard transaction: submit → provision → execute → certify → commit
+3. Conflicting transactions: two txns touching same substates
+4. Byzantine proposer: invalid blocks, duplicate proposals
+5. Network partition: shard isolated, then reconnected
+6. Property-based tests with `proptest` for transaction ordering invariants
+
+**Estimated effort:** 2-3 sessions
+**Risk:** Medium — requires deep understanding of the full protocol
+**Why fifth:** High value, establishes us as protocol experts
+
+#### PR #6: Fee Model Design (Issue #17)
+**Target:** New `crates/fees/` or integrated into execution
+**Problem:** No fee mechanism in sharded RE. Who pays? How is it split across shards?
+**Approach:**
+1. Research: how Babylon node handles fees
+2. Propose: fee split proportional to shard execution time
+3. Implement: fee accumulator in execution state
+4. Test: fee collection across single-shard and cross-shard transactions
+
+**Estimated effort:** 3-4 sessions
+**Risk:** High — design decisions, needs maintainer buy-in first
+**Why sixth:** Big impact but needs discussion first. Open an issue with design proposal before coding.
+
+## How We Work
+
+### Before Each PR
+1. **Read the relevant crate end-to-end** — understand the full context
+2. **Run existing tests** — `cargo test -p hyperscale-<crate>`
+3. **Check recent commits** — the codebase moves fast, don't work on stale code
+4. **Open a discussion** on the issue first if the fix is non-obvious
+5. **Pull latest main** — rebase before PR
+
+### PR Standards (Match Their Style)
+- Commit messages: imperative mood, concise ("Add bounded pool eviction to mempool")
+- Code style: follow existing patterns (they use `rustfmt` + `clippy`)
+- Tests: every behavior change has a test
+- No unnecessary refactoring — fix the issue, nothing more
+- Docs: inline comments for non-obvious logic
+
+### Communication
+- Comment on issues before starting work (avoid duplicated effort)
+- Link PR to issue ("Fixes #22 — bounded mempool pool")
+- Be concise in PR descriptions — what changed, why, how to test
+- Respond to review comments promptly
+
+## Don't Touch (Yet)
+
+| Area | Why |
+|------|-----|
+| Consensus protocol changes (#10, #11, #12) | Design decisions still in flux |
+| Gateway integration (#7, #8) | Operational, not our domain |
+| TLA+ verification (#3) | Requires formal methods expertise |
+| Topology changes (#10, #16) | Architectural decisions pending |
+| radix-transactions fork (#4, #43) | Upstream dependency, maintainer territory |
+
+## Tools & Setup
+
+```bash
+# Build
+cd /Users/bigdev/Projects/hyperscale-rs
+cargo build --release
+
+# Test specific crate
+cargo test -p hyperscale-mempool
+cargo test -p hyperscale-bft
+cargo test -p hyperscale-livelock
+
+# Full test suite
+cargo test
+
+# Clippy (must pass for CI)
+cargo clippy --all-targets
+
+# Benchmark (after PR #4)
+cargo bench -p hyperscale-mempool
+```
+
+## Timeline
+
+| Week | PR | Status |
+|------|----|--------|
+| Week 1 | #1 Bounded mempool | Ready to start |
+| Week 1-2 | #2 Livelock tombstone cleanup | After #1 merges |
+| Week 2-3 | #3 Execution early state cleanup | After #2 |
+| Week 3-4 | #4 Benchmarks | Can parallel with #3 |
+| Month 2 | #5 Test suite | After learning from PRs 1-4 |
+| Month 2-3 | #6 Fee model proposal | Needs discussion first |
+
+## Success Metrics
+
+- [ ] PR #1 merged (establishes contributor status)
+- [ ] 3 PRs merged within first month
+- [ ] Maintainer recognizes us as regular contributor
+- [ ] Invited to discussions on protocol design
+- [ ] Benchmarks become part of CI

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,123 @@
+# Hyperscale-RS Handoff — 2026-04-09
+
+## What This Project Is
+Rust BFT consensus protocol for Radix. 55K LOC, 28 crates, 738 tests. Built by hyperscalers team. We're contributing as external collaborators.
+
+## Repo
+- Upstream: https://github.com/hyperscalers/hyperscale-rs
+- Our fork: https://github.com/bigdevxrd/hyperscale-rs
+- Local: /Users/bigdev/Projects/hyperscale-rs
+- Builds clean on Mac (`cargo check` passes)
+
+## What We've Done So Far
+1. **Forked + cloned** (Apr 8)
+2. **Full security audit** — 17 unbounded data structures found across 5 crates, 3 critical
+3. **Posted audit on issue #22** — https://github.com/hyperscalers/hyperscale-rs/issues/22#issuecomment-4205053762
+4. **Researcher agent** triaged all 21 open issues and recommended contribution path
+5. **CONTRIBUTION-PLAN.md** written — 6-PR phased approach
+
+## No Response Yet From Maintainer
+Our #22 comment is the only external contribution. No reply yet. But the maintainer made 10 commits on Apr 8 (same day), merged 5 PRs in 2 weeks. Very active, just hasn't responded to our audit yet.
+
+Hashlock (security audit firm) also opened #52 introducing themselves — signals the project is getting attention.
+
+## First PR: Bounded Mempool Pool
+
+**Target:** `crates/mempool/src/state.rs`
+
+**Problem:** `pool: BTreeMap<Hash, PoolEntry>` grows without bound. `DEFAULT_IN_FLIGHT_LIMIT` (12,288) throttles proposals but doesn't evict old transactions. Attacker can flood with cross-shard txns that never finalize.
+
+**Fix:**
+1. Add `max_pool_size: usize` to config (default 50,000)
+2. Add `fn maybe_evict(&mut self)` after every insert
+3. FIFO eviction by `created_at` (simplest, least controversial)
+4. Add `mempool_pool_size` metric gauge
+5. Test: pool reaches limit → oldest evicted on next insert
+
+**Key files to read:**
+- `crates/mempool/src/state.rs` — the full mempool state (2,151 LOC)
+- `crates/mempool/src/config.rs` — where to add max_pool_size
+- `crates/core/src/lib.rs` — Action enum, ProtocolEvent (understand the event model)
+- `crates/simulation/tests/` — see how existing tests work
+
+**Before starting:**
+```bash
+cd /Users/bigdev/Projects/hyperscale-rs
+git pull origin main  # Codebase moves fast
+cargo test -p hyperscale-mempool  # Run existing tests
+```
+
+## Second PR: Livelock Tombstone Cleanup
+
+**Target:** `crates/livelock/src/state.rs`
+**Problem:** `tombstones: HashMap<Hash, Duration>` — no cleanup despite `tombstone_ttl` config
+**Fix:** Add `cleanup_tombstones(committed_height)` matching mempool's cleanup pattern
+**Effort:** 2-3 hours, very low risk
+
+## Third PR: Execution Early State Cleanup
+
+**Target:** `crates/execution/src/state.rs`
+**Problem:** `early_provisioning_complete`, `early_certificates`, `early_votes` leak on orphaned blocks
+**Fix:** Age-based cleanup in `prune_execution_state()`, remove entries older than committed_height - 100
+**Effort:** 4-6 hours, medium risk
+
+## Architecture Quick Reference
+
+```
+NodeInput → IoLoop → ProtocolEvent → NodeStateMachine
+  ├── BftState (11,925 LOC) — HotStuff-2 consensus
+  ├── ExecutionState (2,776 LOC) — cross-shard 2PC
+  ├── MempoolState (2,151 LOC) — tx pool ← OUR TARGET
+  ├── ProvisionCoordinator — cross-shard state
+  ├── RemoteHeaderCoordinator — remote block headers
+  ├── LivelockState (1,524 LOC) — deadlock detection ← PR #2
+  └── TopologyState — shard membership
+```
+
+All state machine logic is **synchronous, deterministic, pure** (no I/O). I/O deferred to runner layer.
+
+## Key Crates By Size
+
+| Crate | LOC | What |
+|-------|-----|------|
+| bft | 11,925 | Core consensus (don't touch yet) |
+| types | 7,157 | Domain types (foundation) |
+| storage-rocksdb | 4,956 | Production storage |
+| execution | 2,776 | Cross-shard execution |
+| mempool | 2,151 | Transaction pool (PR #1) |
+| engine | 2,083 | Radix Engine integration |
+| production | 1,890 | Async tokio runner |
+| node | 1,840 | Composes all subsystems |
+| livelock | 1,524 | Deadlock detection (PR #2) |
+
+## PR Standards (Match Their Style)
+- `rustfmt` + `clippy` must pass (CI enforces)
+- Imperative commit messages ("Add bounded pool eviction")
+- Every behavior change has a test
+- Comment on the issue before starting work
+- Keep PRs focused — one fix per PR
+
+## Don't Touch
+- Consensus protocol (#10, #11, #12) — design decisions pending
+- Gateway integration (#7, #8) — operational
+- TLA+ (#3) — formal methods
+- radix-transactions fork (#4, #43) — upstream dep
+
+## Files in This Repo
+- `CLAUDE.md` — project context for Claude Code sessions
+- `CONTRIBUTION-PLAN.md` — full 6-PR phased plan with timeline
+- `HANDOFF.md` — this file
+
+## Agent Support
+- `bigdev-agents` CLI can run the researcher agent for analysis:
+  ```bash
+  cd /Users/bigdev/Projects/bigdev-agents
+  ANTHROPIC_API_KEY=<key> node scripts/run-agent.js researcher --profile hyperscale "<question>"
+  ```
+- Budget: Haiku for research ($0.001/1k tokens), free models for quick questions
+- Yesterday's agent output: `bigdev-agents/output/researcher-2026-04-08T10-01-54.md` (issue triage)
+
+## Memory References
+- `~/.claude/projects/-Users-bigdev-Projects-auto-trader-xrd/memory/project_agent_architecture.md` — agent setup
+- `openclaw-bert/workspace/PROJECT-HYPERSCALERS.md` — Bert's original analysis (20 issues mapped)
+- `scrypto-xrd/SCRYPTO-AUDIT-2026-04-08.md` — our Scrypto audit methodology (same rigor)

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -102,6 +102,7 @@ pub struct ExecutionMemoryStats {
     pub accumulators: usize,
     pub vote_trackers: usize,
     pub early_votes: usize,
+    pub early_wave_attestations: usize,
     pub wave_certificate_trackers: usize,
     pub expected_exec_certs: usize,
 }
@@ -1766,11 +1767,22 @@ impl ExecutionState {
         });
         let pruned_ev = before_ev - self.early_votes.len();
 
-        if pruned_acc > 0 || pruned_vt > 0 || pruned_ev > 0 {
+        // Prune stale early wave attestations that were never consumed.
+        // Attestations are consumed during setup_execution_tracking when wave
+        // trackers exist. Attestations may also be re-buffered if some waves
+        // are unrouted (handle_wave_attestation). Entries 50 or more blocks
+        // old (insertion_height <= cutoff) are pruned to prevent unbounded growth.
+        let before_ewa = self.early_wave_attestations.len();
+        self.early_wave_attestations
+            .retain(|(_, insertion_height)| *insertion_height > ev_cutoff);
+        let pruned_ewa = before_ewa - self.early_wave_attestations.len();
+
+        if pruned_acc > 0 || pruned_vt > 0 || pruned_ev > 0 || pruned_ewa > 0 {
             tracing::debug!(
                 pruned_acc,
                 pruned_vt,
                 pruned_ev,
+                pruned_ewa,
                 "Pruned resolved wave state"
             );
         }
@@ -1896,6 +1908,7 @@ impl ExecutionState {
             accumulators: self.accumulators.len(),
             vote_trackers: self.vote_trackers.len(),
             early_votes: self.early_votes.len(),
+            early_wave_attestations: self.early_wave_attestations.len(),
             wave_certificate_trackers: self.wave_certificate_trackers.len(),
             expected_exec_certs: self.expected_exec_certs.len(),
         }
@@ -2105,6 +2118,122 @@ mod tests {
             results,
             vec![true, false],
             "Second signature should fail verification"
+        );
+    }
+
+    // ========================================================================
+    // Early Wave Attestations Cleanup Tests
+    // ========================================================================
+
+    /// Create a dummy ExecutionCertificate for testing.
+    fn make_test_ec(tx_seed: u8) -> Arc<ExecutionCertificate> {
+        use hyperscale_types::{zero_bls_signature, SignerBitfield, TxOutcome};
+        let tx = test_transaction(tx_seed);
+        Arc::new(ExecutionCertificate {
+            wave_id: WaveId::new(ShardGroupId(0), 0, BTreeSet::new()),
+            vote_height: 0,
+            global_receipt_root: Hash::ZERO,
+            tx_outcomes: vec![TxOutcome {
+                tx_hash: tx.hash(),
+                outcome: ExecutionOutcome::Aborted,
+            }],
+            aggregated_signature: zero_bls_signature(),
+            signers: SignerBitfield::new(1),
+        })
+    }
+
+    #[test]
+    fn test_early_wave_attestations_pruned_when_stale() {
+        let mut state = make_test_state();
+
+        // Buffer an attestation at height 40.
+        state.committed_height = 40;
+        let ec = make_test_ec(1);
+        state
+            .early_wave_attestations
+            .push((ec, state.committed_height));
+        assert_eq!(state.early_wave_attestations.len(), 1);
+
+        // Advance to height 100 and prune (cutoff = 50, entry at 40 is stale).
+        state.committed_height = 100;
+        state.prune_execution_state();
+
+        assert_eq!(
+            state.early_wave_attestations.len(),
+            0,
+            "Stale early wave attestation should be pruned"
+        );
+    }
+
+    #[test]
+    fn test_early_wave_attestations_kept_when_fresh() {
+        let mut state = make_test_state();
+
+        // Buffer an attestation at height 80.
+        state.committed_height = 80;
+        let ec = make_test_ec(2);
+        state
+            .early_wave_attestations
+            .push((ec, state.committed_height));
+
+        // Advance to height 100 and prune (cutoff = 50, entry at 80 > 50).
+        state.committed_height = 100;
+        state.prune_execution_state();
+
+        assert_eq!(
+            state.early_wave_attestations.len(),
+            1,
+            "Fresh early wave attestation should be kept"
+        );
+    }
+
+    #[test]
+    fn test_early_wave_attestations_mixed_ages() {
+        let mut state = make_test_state();
+
+        // Buffer attestations at different heights.
+        state.committed_height = 10;
+        state
+            .early_wave_attestations
+            .push((make_test_ec(1), state.committed_height));
+
+        state.committed_height = 60;
+        state
+            .early_wave_attestations
+            .push((make_test_ec(2), state.committed_height));
+
+        state.committed_height = 90;
+        state
+            .early_wave_attestations
+            .push((make_test_ec(3), state.committed_height));
+
+        assert_eq!(state.early_wave_attestations.len(), 3);
+
+        // Advance to height 100 (cutoff = 50). Entry at 10 is stale, 60 and 90 are fresh.
+        state.committed_height = 100;
+        state.prune_execution_state();
+
+        assert_eq!(
+            state.early_wave_attestations.len(),
+            2,
+            "Only the stale attestation (height 10) should be pruned"
+        );
+    }
+
+    #[test]
+    fn test_memory_stats_includes_early_wave_attestations() {
+        let mut state = make_test_state();
+
+        for i in 0..3u8 {
+            state
+                .early_wave_attestations
+                .push((make_test_ec(10 + i), 50));
+        }
+
+        let stats = state.memory_stats();
+        assert_eq!(
+            stats.early_wave_attestations, 3,
+            "memory_stats should report early_wave_attestations count"
         );
     }
 }

--- a/crates/metrics-prometheus/src/lib.rs
+++ b/crates/metrics-prometheus/src/lib.rs
@@ -1166,6 +1166,10 @@ impl MetricsRecorder for PrometheusRecorder {
             .set(m.exec_early_votes as f64);
         self.metrics
             .memory_exec
+            .with_label_values(&["early_wave_attestations"])
+            .set(m.exec_early_wave_attestations as f64);
+        self.metrics
+            .memory_exec
             .with_label_values(&["wave_certificate_trackers"])
             .set(m.exec_wave_certificate_trackers as f64);
         self.metrics

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -87,6 +87,8 @@ pub struct MemoryMetrics {
     pub exec_vote_trackers: usize,
     /// Votes that arrived before tracking started.
     pub exec_early_votes: usize,
+    /// Execution certificates that arrived before wave tracker creation.
+    pub exec_early_wave_attestations: usize,
     /// Wave-level finalization trackers.
     pub exec_wave_certificate_trackers: usize,
     /// Expected execution certificates from remote shards.

--- a/crates/node/src/io_loop/mod.rs
+++ b/crates/node/src/io_loop/mod.rs
@@ -1063,6 +1063,7 @@ where
             exec_accumulators: exec_mem.accumulators,
             exec_vote_trackers: exec_mem.vote_trackers,
             exec_early_votes: exec_mem.early_votes,
+            exec_early_wave_attestations: exec_mem.early_wave_attestations,
             exec_wave_certificate_trackers: exec_mem.wave_certificate_trackers,
             exec_expected_exec_certs: exec_mem.expected_exec_certs,
             // Mempool


### PR DESCRIPTION
## Summary

Adds age-based pruning for `early_wave_attestations` in the execution state machine, preventing unbounded growth when ExecutionCertificates arrive before wave trackers are created and the block never commits (orphaned blocks, sync stalls).

- Prunes entries older than 50 blocks in `prune_execution_state()`, matching the existing `early_votes` pattern
- Re-buffered attestations (unrouted waves) get a fresh `committed_height` stamp, so actively cycling ECs are never falsely pruned
- New `early_wave_attestations` Prometheus metric for monitoring

Addresses early state cleanup identified in #22.

## Changes

| File | What |
|------|------|
| `crates/execution/src/state.rs` | `retain()` in `prune_execution_state()` with 50-block cutoff, `ExecutionMemoryStats` field, 4 tests |
| `crates/metrics/src/lib.rs` | `exec_early_wave_attestations` in `MemoryMetrics` |
| `crates/metrics-prometheus/src/lib.rs` | Prometheus gauge emission |
| `crates/node/src/io_loop/mod.rs` | Metrics pipeline mapping |

## Test plan

- [x] 4 new tests: stale pruned, fresh kept, mixed ages, memory_stats
- [x] All 31 execution tests pass (27 existing + 4 new)
- [x] Full workspace suite passes (500+ tests)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt -- --check` clean