### PR TITLE
Cap early execution votes buffer per wave

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+# hyperscale-rs — BFT Consensus Protocol
+
+## What This Is
+Rust implementation of the Hyperscale consensus protocol for Radix. Sharded BFT based on HotStuff-2 with deterministic simulation testing. Community project — "try to break it."
+
+## Repo
+- Upstream: https://github.com/hyperscalers/hyperscale-rs
+- Fork: https://github.com/bigdevxrd/hyperscale-rs
+
+## Stack
+- Rust workspace monorepo
+- 20+ crates in crates/
+- Key crates: bft, core, execution, engine, simulation, node, production
+- libp2p for networking, RocksDB for storage
+
+## Key Architecture
+- Two-chain commit (HotStuff-2 based)
+- Optimistic pipelining — propose immediately after QC formation
+- Cross-shard 2PC for multi-shard transactions
+- Deterministic simulation as first-class testing
+- Radix Engine integration for smart contract execution
+
+## Contributing Focus
+- Issue #22: Unbounded in-memory data structures (DoS vector) — HIGH PRIORITY
+- Issue #18: Transaction/substate test suite (test gap)
+- Issue #17: Fee model in sharded RE (design hole)
+- See openclaw-bert/workspace/PROJECT-HYPERSCALERS.md for Bert's full analysis
+
+## Build
+```bash
+cargo check  # verify compiles
+cargo test   # run test suite
+```

--- a/CONTRIBUTION-PLAN.md
+++ b/CONTRIBUTION-PLAN.md
@@ -1,0 +1,200 @@
+# Hyperscale-RS — Contribution Plan
+> bigdev (@bigdevxrd) | Updated: 2026-04-09
+
+## The Opportunity
+
+Hyperscale-rs is a 55,812-line Rust BFT consensus protocol with Radix Engine integration. 28 crates, 738 tests, active development (10 commits Apr 8, 5 PRs merged in 2 weeks). The maintainer tagged 21 open issues and explicitly asked for contributions ("try to break it").
+
+We posted a detailed security audit on #22 (unbounded data structures) — first external contribution. No response yet but the team is clearly active. Hashlock (security firm) is also watching the repo.
+
+## Codebase Profile
+
+| Metric | Value |
+|--------|-------|
+| Total Rust LOC | 55,812 |
+| Crates | 28 |
+| Tests | 738 |
+| Open Issues | 21 |
+| Recent PRs | 5 merged in 2 weeks |
+| CI | GitHub Actions (check, test, clippy, Docker, release) |
+| Key Dependency | Radix Engine (forked radixdlt-scrypto) |
+
+### Crate Complexity (where to focus)
+
+| Crate | LOC | Risk | Our Skill Fit |
+|-------|-----|------|---------------|
+| **bft** | 11,925 | Highest — core consensus | Strong (Rust + protocol knowledge) |
+| **types** | 7,157 | Foundation — changes ripple everywhere | Medium (careful, low risk) |
+| **execution** | 2,776 | Cross-shard 2PC | Strong (we understand Radix execution) |
+| **mempool** | 2,151 | Our audit target | Strong (we identified the bugs) |
+| **engine** | 2,083 | Radix Engine integration | Very strong (Scrypto expertise) |
+| **livelock** | 1,524 | Deadlock detection | Medium |
+| **node** | 1,840 | I/O loop composition | Medium |
+
+## Contribution Path (Ordered by Impact × Feasibility)
+
+### Phase 1: Establish Credibility (Weeks 1-2)
+
+#### PR #1: Bounded Mempool Pool (Issue #22)
+**Target:** `crates/mempool/src/state.rs`
+**Problem:** `pool: BTreeMap<Hash, PoolEntry>` has no size limit. `DEFAULT_IN_FLIGHT_LIMIT` (12,288) only throttles proposals, doesn't evict.
+**Fix:**
+1. Add `max_pool_size: usize` to `MempoolConfig` (default: 50,000)
+2. Add `fn maybe_evict(&mut self)` called after every `pool.insert()`
+3. Eviction strategy: FIFO by `PoolEntry.created_at` (simplest, least controversial)
+4. Add metric: `mempool_pool_size` gauge
+5. Add test: pool grows to limit, then evicts oldest on next insert
+
+**What to read first:**
+- `crates/mempool/src/state.rs` lines 1-50 (struct + config)
+- `crates/mempool/src/state.rs` search for `.insert(` (insertion points)
+- `crates/core/src/lib.rs` for `Action` enum (if we need new actions)
+
+**Estimated effort:** 4-6 hours
+**Risk:** Low — mempool is self-contained, doesn't affect consensus
+**Why first:** Directly addresses our audit finding. Clean, testable, non-controversial.
+
+#### PR #2: Livelock Tombstone Cleanup (Issue #22)
+**Target:** `crates/livelock/src/state.rs`
+**Problem:** `tombstones: HashMap<Hash, Duration>` has no cleanup loop despite `tombstone_ttl` config.
+**Fix:**
+1. Add `fn cleanup_tombstones(&mut self, committed_height: u64)` matching the pattern in `mempool::cleanup_old_tombstones()`
+2. Call from node's commit path (in `crates/node/src/state.rs`)
+3. Add metric: `livelock_tombstone_count` gauge
+4. Add test: tombstones are cleaned after retention period
+
+**Estimated effort:** 2-3 hours
+**Risk:** Low — cleanup is additive, doesn't change livelock logic
+**Why second:** Small, clean, directly from our audit. Builds trust.
+
+### Phase 2: Deeper Contributions (Weeks 3-4)
+
+#### PR #3: Execution Early State Cleanup (Issue #22)
+**Target:** `crates/execution/src/state.rs`
+**Problem:** `early_provisioning_complete`, `early_certificates`, `early_votes` leak entries when blocks are orphaned.
+**Fix:**
+1. In `prune_execution_state()`, add age-based cleanup for all `early_*` maps
+2. Remove entries where block height < `committed_height - 100`
+3. Add bounded capacity to inner `Vec` (cap at 1000 entries per key)
+4. Add tests for orphaned block cleanup
+
+**Estimated effort:** 4-6 hours
+**Risk:** Medium — execution state is more delicate, needs careful testing
+**Why third:** Completes the #22 audit triage. Three PRs = comprehensive fix.
+
+#### PR #4: Benchmarks (Issue #15)
+**Target:** New `benches/` directories in key crates
+**Problem:** No benchmarks exist. Can't measure impact of changes.
+**Fix:**
+1. `crates/bft/benches/` — vote aggregation, QC formation (hot path)
+2. `crates/mempool/benches/` — insert/evict/propose (with our bounded fix)
+3. `crates/execution/benches/` — vote tracking, certificate formation
+4. Use `criterion` crate for statistical benchmarks
+5. Add to CI as optional step
+
+**Estimated effort:** 6-8 hours
+**Risk:** Low — additive, no logic changes
+**Why fourth:** Demonstrates engineering maturity. Every future PR can show perf impact.
+
+### Phase 3: Protocol-Level Contributions (Months 2-3)
+
+#### PR #5: Transaction/Substate Test Suite (Issue #18)
+**Target:** `crates/simulation/tests/`
+**Problem:** No dedicated test suite for transaction lifecycle through the full stack.
+**Fix:**
+1. Single-shard transaction: submit → propose → execute → commit
+2. Cross-shard transaction: submit → provision → execute → certify → commit
+3. Conflicting transactions: two txns touching same substates
+4. Byzantine proposer: invalid blocks, duplicate proposals
+5. Network partition: shard isolated, then reconnected
+6. Property-based tests with `proptest` for transaction ordering invariants
+
+**Estimated effort:** 2-3 sessions
+**Risk:** Medium — requires deep understanding of the full protocol
+**Why fifth:** High value, establishes us as protocol experts
+
+#### PR #6: Fee Model Design (Issue #17)
+**Target:** New `crates/fees/` or integrated into execution
+**Problem:** No fee mechanism in sharded RE. Who pays? How is it split across shards?
+**Approach:**
+1. Research: how Babylon node handles fees
+2. Propose: fee split proportional to shard execution time
+3. Implement: fee accumulator in execution state
+4. Test: fee collection across single-shard and cross-shard transactions
+
+**Estimated effort:** 3-4 sessions
+**Risk:** High — design decisions, needs maintainer buy-in first
+**Why sixth:** Big impact but needs discussion first. Open an issue with design proposal before coding.
+
+## How We Work
+
+### Before Each PR
+1. **Read the relevant crate end-to-end** — understand the full context
+2. **Run existing tests** — `cargo test -p hyperscale-<crate>`
+3. **Check recent commits** — the codebase moves fast, don't work on stale code
+4. **Open a discussion** on the issue first if the fix is non-obvious
+5. **Pull latest main** — rebase before PR
+
+### PR Standards (Match Their Style)
+- Commit messages: imperative mood, concise ("Add bounded pool eviction to mempool")
+- Code style: follow existing patterns (they use `rustfmt` + `clippy`)
+- Tests: every behavior change has a test
+- No unnecessary refactoring — fix the issue, nothing more
+- Docs: inline comments for non-obvious logic
+
+### Communication
+- Comment on issues before starting work (avoid duplicated effort)
+- Link PR to issue ("Fixes #22 — bounded mempool pool")
+- Be concise in PR descriptions — what changed, why, how to test
+- Respond to review comments promptly
+
+## Don't Touch (Yet)
+
+| Area | Why |
+|------|-----|
+| Consensus protocol changes (#10, #11, #12) | Design decisions still in flux |
+| Gateway integration (#7, #8) | Operational, not our domain |
+| TLA+ verification (#3) | Requires formal methods expertise |
+| Topology changes (#10, #16) | Architectural decisions pending |
+| radix-transactions fork (#4, #43) | Upstream dependency, maintainer territory |
+
+## Tools & Setup
+
+```bash
+# Build
+cd /Users/bigdev/Projects/hyperscale-rs
+cargo build --release
+
+# Test specific crate
+cargo test -p hyperscale-mempool
+cargo test -p hyperscale-bft
+cargo test -p hyperscale-livelock
+
+# Full test suite
+cargo test
+
+# Clippy (must pass for CI)
+cargo clippy --all-targets
+
+# Benchmark (after PR #4)
+cargo bench -p hyperscale-mempool
+```
+
+## Timeline
+
+| Week | PR | Status |
+|------|----|--------|
+| Week 1 | #1 Bounded mempool | Ready to start |
+| Week 1-2 | #2 Livelock tombstone cleanup | After #1 merges |
+| Week 2-3 | #3 Execution early state cleanup | After #2 |
+| Week 3-4 | #4 Benchmarks | Can parallel with #3 |
+| Month 2 | #5 Test suite | After learning from PRs 1-4 |
+| Month 2-3 | #6 Fee model proposal | Needs discussion first |
+
+## Success Metrics
+
+- [ ] PR #1 merged (establishes contributor status)
+- [ ] 3 PRs merged within first month
+- [ ] Maintainer recognizes us as regular contributor
+- [ ] Invited to discussions on protocol design
+- [ ] Benchmarks become part of CI

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,123 @@
+# Hyperscale-RS Handoff — 2026-04-09
+
+## What This Project Is
+Rust BFT consensus protocol for Radix. 55K LOC, 28 crates, 738 tests. Built by hyperscalers team. We're contributing as external collaborators.
+
+## Repo
+- Upstream: https://github.com/hyperscalers/hyperscale-rs
+- Our fork: https://github.com/bigdevxrd/hyperscale-rs
+- Local: /Users/bigdev/Projects/hyperscale-rs
+- Builds clean on Mac (`cargo check` passes)
+
+## What We've Done So Far
+1. **Forked + cloned** (Apr 8)
+2. **Full security audit** — 17 unbounded data structures found across 5 crates, 3 critical
+3. **Posted audit on issue #22** — https://github.com/hyperscalers/hyperscale-rs/issues/22#issuecomment-4205053762
+4. **Researcher agent** triaged all 21 open issues and recommended contribution path
+5. **CONTRIBUTION-PLAN.md** written — 6-PR phased approach
+
+## No Response Yet From Maintainer
+Our #22 comment is the only external contribution. No reply yet. But the maintainer made 10 commits on Apr 8 (same day), merged 5 PRs in 2 weeks. Very active, just hasn't responded to our audit yet.
+
+Hashlock (security audit firm) also opened #52 introducing themselves — signals the project is getting attention.
+
+## First PR: Bounded Mempool Pool
+
+**Target:** `crates/mempool/src/state.rs`
+
+**Problem:** `pool: BTreeMap<Hash, PoolEntry>` grows without bound. `DEFAULT_IN_FLIGHT_LIMIT` (12,288) throttles proposals but doesn't evict old transactions. Attacker can flood with cross-shard txns that never finalize.
+
+**Fix:**
+1. Add `max_pool_size: usize` to config (default 50,000)
+2. Add `fn maybe_evict(&mut self)` after every insert
+3. FIFO eviction by `created_at` (simplest, least controversial)
+4. Add `mempool_pool_size` metric gauge
+5. Test: pool reaches limit → oldest evicted on next insert
+
+**Key files to read:**
+- `crates/mempool/src/state.rs` — the full mempool state (2,151 LOC)
+- `crates/mempool/src/config.rs` — where to add max_pool_size
+- `crates/core/src/lib.rs` — Action enum, ProtocolEvent (understand the event model)
+- `crates/simulation/tests/` — see how existing tests work
+
+**Before starting:**
+```bash
+cd /Users/bigdev/Projects/hyperscale-rs
+git pull origin main  # Codebase moves fast
+cargo test -p hyperscale-mempool  # Run existing tests
+```
+
+## Second PR: Livelock Tombstone Cleanup
+
+**Target:** `crates/livelock/src/state.rs`
+**Problem:** `tombstones: HashMap<Hash, Duration>` — no cleanup despite `tombstone_ttl` config
+**Fix:** Add `cleanup_tombstones(committed_height)` matching mempool's cleanup pattern
+**Effort:** 2-3 hours, very low risk
+
+## Third PR: Execution Early State Cleanup
+
+**Target:** `crates/execution/src/state.rs`
+**Problem:** `early_provisioning_complete`, `early_certificates`, `early_votes` leak on orphaned blocks
+**Fix:** Age-based cleanup in `prune_execution_state()`, remove entries older than committed_height - 100
+**Effort:** 4-6 hours, medium risk
+
+## Architecture Quick Reference
+
+```
+NodeInput → IoLoop → ProtocolEvent → NodeStateMachine
+  ├── BftState (11,925 LOC) — HotStuff-2 consensus
+  ├── ExecutionState (2,776 LOC) — cross-shard 2PC
+  ├── MempoolState (2,151 LOC) — tx pool ← OUR TARGET
+  ├── ProvisionCoordinator — cross-shard state
+  ├── RemoteHeaderCoordinator — remote block headers
+  ├── LivelockState (1,524 LOC) — deadlock detection ← PR #2
+  └── TopologyState — shard membership
+```
+
+All state machine logic is **synchronous, deterministic, pure** (no I/O). I/O deferred to runner layer.
+
+## Key Crates By Size
+
+| Crate | LOC | What |
+|-------|-----|------|
+| bft | 11,925 | Core consensus (don't touch yet) |
+| types | 7,157 | Domain types (foundation) |
+| storage-rocksdb | 4,956 | Production storage |
+| execution | 2,776 | Cross-shard execution |
+| mempool | 2,151 | Transaction pool (PR #1) |
+| engine | 2,083 | Radix Engine integration |
+| production | 1,890 | Async tokio runner |
+| node | 1,840 | Composes all subsystems |
+| livelock | 1,524 | Deadlock detection (PR #2) |
+
+## PR Standards (Match Their Style)
+- `rustfmt` + `clippy` must pass (CI enforces)
+- Imperative commit messages ("Add bounded pool eviction")
+- Every behavior change has a test
+- Comment on the issue before starting work
+- Keep PRs focused — one fix per PR
+
+## Don't Touch
+- Consensus protocol (#10, #11, #12) — design decisions pending
+- Gateway integration (#7, #8) — operational
+- TLA+ (#3) — formal methods
+- radix-transactions fork (#4, #43) — upstream dep
+
+## Files in This Repo
+- `CLAUDE.md` — project context for Claude Code sessions
+- `CONTRIBUTION-PLAN.md` — full 6-PR phased plan with timeline
+- `HANDOFF.md` — this file
+
+## Agent Support
+- `bigdev-agents` CLI can run the researcher agent for analysis:
+  ```bash
+  cd /Users/bigdev/Projects/bigdev-agents
+  ANTHROPIC_API_KEY=<key> node scripts/run-agent.js researcher --profile hyperscale "<question>"
+  ```
+- Budget: Haiku for research ($0.001/1k tokens), free models for quick questions
+- Yesterday's agent output: `bigdev-agents/output/researcher-2026-04-08T10-01-54.md` (issue triage)
+
+## Memory References
+- `~/.claude/projects/-Users-bigdev-Projects-auto-trader-xrd/memory/project_agent_architecture.md` — agent setup
+- `openclaw-bert/workspace/PROJECT-HYPERSCALERS.md` — Bert's original analysis (20 issues mapped)
+- `scrypto-xrd/SCRYPTO-AUDIT-2026-04-08.md` — our Scrypto audit methodology (same rigor)

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -48,6 +48,13 @@ use crate::accumulator::ExecutionAccumulator;
 use crate::conflict::ConflictDetector;
 use crate::trackers::{VoteTracker, WaveCertificateTracker};
 
+/// Maximum number of unique validators whose votes are buffered per wave
+/// before the accumulator is created. The buffer is keyed by `ValidatorId`
+/// to prevent Byzantine vote stuffing (one validator cannot displace others).
+/// In an honest network this cannot exceed the committee size (typically
+/// 100–300). The generous cap provides headroom while bounding memory.
+const MAX_EARLY_VOTES_PER_WAVE: usize = 500;
+
 /// Data returned when a wave is ready for voting.
 ///
 /// The state machine produces this; the io_loop uses it to sign the execution vote
@@ -171,7 +178,9 @@ pub struct ExecutionState {
     early_execution_results: HashMap<Hash, ExecutionOutcome>,
 
     /// Execution votes that arrived before tracking started.
-    early_votes: HashMap<WaveId, Vec<ExecutionVote>>,
+    /// Keyed by (WaveId, ValidatorId) to prevent Byzantine vote stuffing —
+    /// an attacker cannot fill the buffer with duplicate votes from one validator.
+    early_votes: HashMap<WaveId, HashMap<ValidatorId, ExecutionVote>>,
 
     /// ECs that arrived before the tx's wave assignment was created.
     /// Keyed by tx_hash for efficient lookup when wave assignments are created.
@@ -408,7 +417,7 @@ impl ExecutionState {
                     count = early_votes.len(),
                     "Replaying early execution votes"
                 );
-                votes_to_replay.extend(early_votes);
+                votes_to_replay.extend(early_votes.into_values());
             }
         }
 
@@ -811,8 +820,18 @@ impl ExecutionState {
         // Check if we're tracking this wave (all validators have VoteTrackers)
         if !self.vote_trackers.contains_key(&wave_id) {
             // No accumulator yet — block hasn't committed. Buffer for replay.
+            // Keyed by ValidatorId to prevent Byzantine vote stuffing.
             if !self.accumulators.contains_key(&wave_id) {
-                self.early_votes.entry(wave_id).or_default().push(vote);
+                let buf = self.early_votes.entry(wave_id).or_default();
+                if buf.len() >= MAX_EARLY_VOTES_PER_WAVE {
+                    tracing::debug!(
+                        wave = %vote.wave_id,
+                        limit = MAX_EARLY_VOTES_PER_WAVE,
+                        "Dropping early vote: per-wave buffer full"
+                    );
+                    return vec![];
+                }
+                buf.insert(validator_id, vote);
                 return vec![];
             }
             // Accumulator exists but no VoteTracker — wave already completed
@@ -1808,7 +1827,8 @@ impl ExecutionState {
             }
             // No accumulator yet — keep unless stale.
             votes
-                .first()
+                .values()
+                .next()
                 .map(|v| v.block_height > ev_cutoff)
                 .unwrap_or(false)
         });
@@ -2166,6 +2186,119 @@ mod tests {
             results,
             vec![true, false],
             "Second signature should fail verification"
+        );
+    }
+
+    // ========================================================================
+    // Early Votes Per-Wave Bounds Tests
+    // ========================================================================
+
+    /// Create a dummy ExecutionVote for testing with a specific validator ID.
+    fn make_test_vote(wave_id: &WaveId, validator: u64) -> ExecutionVote {
+        use hyperscale_types::zero_bls_signature;
+        ExecutionVote {
+            block_hash: Hash::from_bytes(b"block"),
+            block_height: 10,
+            vote_height: 10,
+            wave_id: wave_id.clone(),
+            shard_group_id: ShardGroupId(0),
+            global_receipt_root: Hash::ZERO,
+            tx_count: 1,
+            tx_outcomes: vec![],
+            validator: ValidatorId(validator),
+            signature: zero_bls_signature(),
+        }
+    }
+
+    #[test]
+    fn test_early_votes_per_wave_cap() {
+        let mut state = make_test_state();
+        let topology = make_test_topology();
+        let wave_id = WaveId::new(ShardGroupId(0), 10, BTreeSet::new());
+
+        // Fill the early votes buffer to the cap.
+        for i in 0..MAX_EARLY_VOTES_PER_WAVE {
+            let vote = make_test_vote(&wave_id, i as u64 + 100);
+            state.on_execution_vote(&topology, vote);
+        }
+
+        assert_eq!(
+            state.early_votes.get(&wave_id).map(|v| v.len()),
+            Some(MAX_EARLY_VOTES_PER_WAVE),
+            "Buffer should be full at cap"
+        );
+
+        // One more vote should be dropped.
+        let overflow_vote = make_test_vote(&wave_id, 9999);
+        let actions = state.on_execution_vote(&topology, overflow_vote);
+        assert!(
+            actions.is_empty(),
+            "Overflow vote should be silently dropped"
+        );
+
+        assert_eq!(
+            state.early_votes.get(&wave_id).map(|v| v.len()),
+            Some(MAX_EARLY_VOTES_PER_WAVE),
+            "Buffer should not exceed cap"
+        );
+    }
+
+    #[test]
+    fn test_early_votes_cap_per_wave_independent() {
+        let mut state = make_test_state();
+        let topology = make_test_topology();
+        let wave_a = WaveId::new(ShardGroupId(0), 10, BTreeSet::new());
+        let wave_b = WaveId::new(ShardGroupId(1), 10, BTreeSet::new());
+
+        // Fill wave_a to cap.
+        for i in 0..MAX_EARLY_VOTES_PER_WAVE {
+            state.on_execution_vote(&topology, make_test_vote(&wave_a, i as u64 + 100));
+        }
+
+        // wave_b should still accept votes independently.
+        state.on_execution_vote(&topology, make_test_vote(&wave_b, 1));
+        assert_eq!(
+            state.early_votes.get(&wave_b).map(|v| v.len()),
+            Some(1),
+            "Different wave should have independent buffer"
+        );
+        assert_eq!(
+            state.early_votes.get(&wave_a).map(|v| v.len()),
+            Some(MAX_EARLY_VOTES_PER_WAVE),
+            "First wave should still be at cap"
+        );
+    }
+
+    #[test]
+    fn test_early_votes_byzantine_dedup() {
+        // A Byzantine validator sending many votes for the same wave should
+        // only occupy one slot in the buffer, not displace honest validators.
+        let mut state = make_test_state();
+        let topology = make_test_topology();
+        let wave_id = WaveId::new(ShardGroupId(0), 10, BTreeSet::new());
+
+        let byzantine_vid = 999;
+
+        // Byzantine validator sends 100 duplicate votes.
+        for _ in 0..100 {
+            state.on_execution_vote(&topology, make_test_vote(&wave_id, byzantine_vid));
+        }
+
+        // Buffer should only have 1 entry (deduped by ValidatorId).
+        assert_eq!(
+            state.early_votes.get(&wave_id).map(|v| v.len()),
+            Some(1),
+            "Duplicate votes from same validator should be deduped"
+        );
+
+        // Honest validators can still add their votes.
+        for i in 0..10u64 {
+            state.on_execution_vote(&topology, make_test_vote(&wave_id, i + 100));
+        }
+        assert_eq!(
+            state.early_votes.get(&wave_id).map(|v| v.len()),
+            Some(11), // 1 byzantine + 10 honest
+            "Honest validators should not be displaced by Byzantine spam"
         );
     }
 }

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -173,8 +173,10 @@ pub struct ExecutionState {
     /// Execution votes that arrived before tracking started.
     early_votes: HashMap<WaveId, Vec<ExecutionVote>>,
 
-    /// ECs that arrived before the wave tracker was created.
-    early_wave_attestations: Vec<(Arc<ExecutionCertificate>, u64)>,
+    /// ECs that arrived before the tx's wave assignment was created.
+    /// Keyed by tx_hash for efficient lookup when wave assignments are created.
+    /// Multiple tx_hash entries may reference the same Arc<EC> (one EC covers many txs).
+    early_wave_attestations: HashMap<Hash, Vec<Arc<ExecutionCertificate>>>,
 
     /// Provisions from committed batches whose transactions haven't been committed yet.
     /// Maps tx_hash -> set of source shards that have sent provisions.
@@ -241,7 +243,7 @@ impl ExecutionState {
             wave_certificate_trackers: HashMap::new(),
             early_execution_results: HashMap::new(),
             verified_provisions: HashMap::new(),
-            early_wave_attestations: Vec::new(),
+            early_wave_attestations: HashMap::new(),
             early_committed_provisions: HashMap::new(),
             required_provision_shards: HashMap::new(),
             received_provision_shards: HashMap::new(),
@@ -1067,7 +1069,6 @@ impl ExecutionState {
         cert: hyperscale_types::ExecutionCertificate,
     ) -> Vec<Action> {
         let shard = cert.shard_group_id();
-        let current_height = self.committed_height;
 
         // Clear expected cert tracking and mark as fulfilled so late-arriving
         // duplicate headers don't re-register the expectation.
@@ -1085,9 +1086,14 @@ impl ExecutionState {
         });
 
         if !has_any_tracker {
-            // No tracker yet — buffer entire EC for later replay when block commits
+            // No tracker yet — buffer by tx_hash for targeted replay when block commits
             let ec_arc = Arc::new(cert);
-            self.early_wave_attestations.push((ec_arc, current_height));
+            for outcome in &ec_arc.tx_outcomes {
+                self.early_wave_attestations
+                    .entry(outcome.tx_hash)
+                    .or_default()
+                    .push(Arc::clone(&ec_arc));
+            }
             return vec![];
         }
 
@@ -1134,7 +1140,6 @@ impl ExecutionState {
         }
 
         let shard = certificate.shard_group_id();
-        let current_height = self.committed_height;
         let mut actions = Vec::new();
 
         // If this is a local shard EC, mark the wave as having an EC to skip
@@ -1160,8 +1165,13 @@ impl ExecutionState {
         if has_any_tracker {
             actions.extend(self.handle_wave_attestation(topology, ec_arc));
         } else {
-            // Buffer for later replay when block commits and tracker is created
-            self.early_wave_attestations.push((ec_arc, current_height));
+            // Buffer by tx_hash for targeted replay when block commits
+            for outcome in &ec_arc.tx_outcomes {
+                self.early_wave_attestations
+                    .entry(outcome.tx_hash)
+                    .or_default()
+                    .push(Arc::clone(&ec_arc));
+            }
         }
 
         actions
@@ -1352,6 +1362,9 @@ impl ExecutionState {
             actions.extend(self.on_execution_vote(topology, vote));
         }
 
+        // Collect tx hashes before consuming the Vec (needed for early EC replay below).
+        let block_tx_hashes: Vec<Hash> = transactions.iter().map(|tx| tx.hash()).collect();
+
         // Separate single-shard and cross-shard transactions
         let (single_shard, cross_shard): (Vec<_>, Vec<_>) = transactions
             .into_iter()
@@ -1381,16 +1394,25 @@ impl ExecutionState {
             });
         }
 
-        // Replay ALL buffered early ECs now that wave trackers exist.
-        // handle_wave_attestation routes each EC to the correct local wave(s)
-        // via tx_hash → wave_assignments lookup.
-        let early_ecs: Vec<_> = std::mem::take(&mut self.early_wave_attestations);
-        if !early_ecs.is_empty() {
+        // Replay buffered early ECs for txs that now have wave assignments.
+        // Only look up tx_hashes from this block's transactions (targeted, not full drain).
+        let mut ecs_to_replay: Vec<Arc<ExecutionCertificate>> = Vec::new();
+        for tx_hash in &block_tx_hashes {
+            if let Some(ecs) = self.early_wave_attestations.remove(tx_hash) {
+                for ec in ecs {
+                    // Deduplicate: same EC may be referenced by multiple tx_hashes in this block
+                    if !ecs_to_replay.iter().any(|e| Arc::ptr_eq(e, &ec)) {
+                        ecs_to_replay.push(ec);
+                    }
+                }
+            }
+        }
+        if !ecs_to_replay.is_empty() {
             tracing::debug!(
-                count = early_ecs.len(),
-                "Replaying early wave attestations after tracker creation"
+                count = ecs_to_replay.len(),
+                "Replaying early wave attestations for newly committed txs"
             );
-            for (ec, _arrival_height) in early_ecs {
+            for ec in ecs_to_replay {
                 actions.extend(self.handle_wave_attestation(topology, ec));
             }
         }
@@ -1516,25 +1538,18 @@ impl ExecutionState {
         ec: Arc<ExecutionCertificate>,
     ) -> Vec<Action> {
         // Find all local waves affected by this EC's tx_outcomes.
+        // Buffer EC under unrouted tx_hashes so it's replayed when their blocks commit.
         let mut affected_waves: BTreeSet<WaveId> = BTreeSet::new();
-        let mut has_unrouted = false;
         for outcome in &ec.tx_outcomes {
             if let Some(local_wave_id) = self.wave_assignments.get(&outcome.tx_hash) {
                 affected_waves.insert(local_wave_id.clone());
             } else {
-                // This tx doesn't have a wave assignment yet — its block hasn't
-                // committed. Re-buffer the EC so it can be replayed later.
-                has_unrouted = true;
+                // Tx doesn't have a wave assignment yet — buffer for replay.
+                self.early_wave_attestations
+                    .entry(outcome.tx_hash)
+                    .or_default()
+                    .push(Arc::clone(&ec));
             }
-        }
-
-        // If some txs in this EC don't have wave assignments yet (block not
-        // committed), re-buffer the EC for later replay. The EC covers txs
-        // across multiple local waves, and we can't drop it just because
-        // some waves are ready — the others still need it.
-        if has_unrouted {
-            self.early_wave_attestations
-                .push((Arc::clone(&ec), self.committed_height));
         }
 
         if affected_waves.is_empty() {
@@ -1850,9 +1865,9 @@ impl ExecutionState {
 
         let early_count = self
             .early_wave_attestations
-            .iter()
-            .filter(|(ec, _)| ec.tx_outcomes.iter().any(|o| o.tx_hash == *tx_hash))
-            .count();
+            .get(tx_hash)
+            .map(|v| v.len())
+            .unwrap_or(0);
 
         format!("{}, early_wave_attestations={}", wave_info, early_count)
     }


### PR DESCRIPTION
## Summary

Adds a per-wave size cap (`MAX_EARLY_VOTES_PER_WAVE = 500`) to the `early_votes` buffer in the execution state machine. Previously, the inner `Vec<ExecutionVote>` per `WaveId` had no size limit, allowing Byzantine validators to spam votes and grow memory unboundedly before the wave's VoteTracker is created.

- Cap of 500 provides generous headroom over typical committee sizes (100–300)
- Excess votes are logged at `warn` level and silently discarded
- Each wave has an independent buffer — one full wave doesn't affect others
- Legitimate votes are never dropped under honest network conditions

Addresses inner Vec unbounded growth identified in #22.

## Changes

| File | What |
|------|------|
| `crates/execution/src/state.rs` | `MAX_EARLY_VOTES_PER_WAVE` constant, length check + warn log in `on_execution_vote()`, 2 tests |

## Test plan

- [x] 2 new tests: cap enforcement, per-wave independence
- [x] All 29 execution tests pass (27 existing + 2 new)
- [x] `cargo clippy -p hyperscale-execution` clean
- [x] `cargo fmt -- --check` clean