### PR TITLE
Add Criterion benchmarks for mempool throughput

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ arc-swap = "1.9.1"
 blake3 = "1.8.4"
 bytes = "1.9"
 clap = { version = "4.6.0", features = ["derive"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 core_affinity = "0.8"
 crossbeam = "0.8.2"
 dashmap = "6.1.0"

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -15,3 +15,8 @@ serde.workspace = true
 
 [dev-dependencies]
 hyperscale-types = { workspace = true, features = ["test-utils"] }
+criterion.workspace = true
+
+[[bench]]
+name = "mempool_throughput"
+harness = false

--- a/crates/mempool/benches/mempool_throughput.rs
+++ b/crates/mempool/benches/mempool_throughput.rs
@@ -1,0 +1,128 @@
+//! Criterion benchmarks for mempool hot paths.
+//!
+//! Measures throughput for transaction submission, gossip acceptance,
+//! and ready transaction selection (block proposal candidate picking).
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use hyperscale_mempool::MempoolState;
+use hyperscale_types::{
+    generate_bls_keypair, test_utils::test_transaction_with_nodes, NodeId, TopologySnapshot,
+    ValidatorId, ValidatorInfo, ValidatorSet,
+};
+use std::sync::Arc;
+use std::time::Duration;
+
+fn make_topology() -> TopologySnapshot {
+    let validators: Vec<_> = (0..4)
+        .map(|i| ValidatorInfo {
+            validator_id: ValidatorId(i),
+            public_key: generate_bls_keypair().public_key(),
+            voting_power: 1,
+        })
+        .collect();
+    TopologySnapshot::new(ValidatorId(0), 1, ValidatorSet::new(validators))
+}
+
+/// Create a unique transaction from an arbitrary index.
+fn make_tx(index: usize) -> Arc<hyperscale_types::RoutableTransaction> {
+    let seed = index.to_le_bytes();
+    let mut node_bytes = [0u8; 30];
+    node_bytes[..seed.len()].copy_from_slice(&seed);
+    Arc::new(test_transaction_with_nodes(
+        &seed,
+        vec![NodeId(node_bytes)],
+        vec![],
+    ))
+}
+
+/// Pre-populate a mempool with `count` unique transactions.
+fn prefilled_mempool(topology: &TopologySnapshot, count: usize) -> MempoolState {
+    let mut mempool = MempoolState::new();
+    for i in 0..count {
+        mempool.on_submit_transaction(topology, make_tx(i));
+    }
+    mempool
+}
+
+fn bench_submit_transaction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("submit_transaction");
+    let topology = make_topology();
+
+    for pool_size in [0, 1_000, 10_000] {
+        group.bench_with_input(
+            BenchmarkId::new("pool_size", pool_size),
+            &pool_size,
+            |b, &size| {
+                b.iter_batched(
+                    || {
+                        let mempool = prefilled_mempool(&topology, size);
+                        let tx = make_tx(size + 100_000);
+                        (mempool, tx)
+                    },
+                    |(mut mempool, tx)| {
+                        black_box(mempool.on_submit_transaction(&topology, tx));
+                    },
+                    criterion::BatchSize::SmallInput,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_transaction_gossip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("transaction_gossip");
+    let topology = make_topology();
+
+    group.bench_function("new_transaction", |b| {
+        b.iter_batched(
+            || (MempoolState::new(), make_tx(1)),
+            |(mut mempool, tx)| {
+                black_box(mempool.on_transaction_gossip(&topology, tx, false));
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("duplicate_rejection", |b| {
+        b.iter_batched(
+            || {
+                let mut mempool = MempoolState::new();
+                let tx = make_tx(1);
+                mempool.on_submit_transaction(&topology, tx.clone());
+                (mempool, tx)
+            },
+            |(mut mempool, tx)| {
+                black_box(mempool.on_transaction_gossip(&topology, tx, false));
+            },
+            criterion::BatchSize::SmallInput,
+        );
+    });
+    group.finish();
+}
+
+fn bench_ready_transactions(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ready_transactions");
+    let topology = make_topology();
+
+    for pool_size in [100, 1_000, 5_000] {
+        group.bench_with_input(
+            BenchmarkId::new("pool_size", pool_size),
+            &pool_size,
+            |b, &size| {
+                let mempool = prefilled_mempool(&topology, size);
+                b.iter(|| {
+                    black_box(mempool.ready_transactions(4096, 0, 0));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().measurement_time(Duration::from_secs(5));
+    targets = bench_submit_transaction, bench_transaction_gossip, bench_ready_transactions
+}
+criterion_main!(benches);


### PR DESCRIPTION
## Summary

Establishes Criterion benchmark infrastructure and adds performance benchmarks for the three mempool hot paths.

### Benchmarks

| Benchmark | What it measures |
|-----------|-----------------|
| `submit_transaction/pool_size/{0,1K,10K}` | Transaction ingestion at varying pool sizes |
| `transaction_gossip/new_transaction` | Gossip acceptance for new transactions |
| `transaction_gossip/duplicate_rejection` | Dedup fast-path for known transactions |
| `ready_transactions/pool_size/{100,1K,5K}` | Block proposal candidate selection |

Run with `cargo bench -p hyperscale-mempool`. HTML reports output to `target/criterion/`.

Addresses #15.

## Changes

| File | What |
|------|------|
| `Cargo.toml` | Add `criterion` to workspace dependencies |
| `crates/mempool/Cargo.toml` | Bench config + criterion dev-dep |
| `crates/mempool/benches/mempool_throughput.rs` | 3 benchmark groups, 8 total benchmarks |

## Test plan

- [x] All mempool tests pass
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt -- --check` clean